### PR TITLE
Create user return key for existing

### DIFF
--- a/src/main/java/edu/harvard/lib/librarycloud/collections/CollectionsAPI.java
+++ b/src/main/java/edu/harvard/lib/librarycloud/collections/CollectionsAPI.java
@@ -311,7 +311,7 @@ public class CollectionsAPI {
     }
 
     /**
-     * Create a user and return api key
+     * Create a user and return api key - requires admin role
      */
     @POST @Path("collections/users")
     @Consumes({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
@@ -321,32 +321,17 @@ public class CollectionsAPI {
         User user = (User)securityContext.getUserPrincipal();
 
         if (user == null) { //user not found.
-            //String jsonErr = "{\"api-key\": \"" + newUser.getToken() + "\"}";
-            //return Response.status(Status.UNAUTHORIZED).entity("{\"error\":\"Not Authorized\"}").type(MediaType.APPLICATION_JSON).build();
             throw new LibraryCloudCollectionsException("Not Authorized", Status.UNAUTHORIZED);
         }
-        //System.out.println("ROLE: " + user.getRole());
         if (!user.getRole().equals("3")) { //user not admin status.
-            //return Response.status(Status.UNAUTHORIZED).entity("{\"error\":\"Not Authorized\"}").type(MediaType.APPLICATION_JSON).build();
             throw new LibraryCloudCollectionsException("Not Authorized", Status.UNAUTHORIZED);
         }
         try {
-            Integer id = collectionDao.createUser(newUser);
-            UriBuilder uriBuilder = uriInfo.getAbsolutePathBuilder();
-            URI uri = uriBuilder.path(id.toString()).build();
-            //System.out.println("URI: " + uri);
+            newUser = collectionDao.createUser(newUser);
         } catch (Exception e) {
-            //return Response.status(500).entity("{\"error\":\"Error, please contact LTS Support\"}").type(MediaType.APPLICATION_JSON).build();
             throw new LibraryCloudCollectionsException("Error, please contact LTS Support", Status.INTERNAL_SERVER_ERROR);
         }
-
-        //GenericEntity entity = new GenericEntity<User>(newUser){};
-        //return Response.ok(entity).build();
-        //return Response.created(uri).build();
-        //NewUser nu = new NewUser(newUser.getEmail(),newUser.getToken());
         GenericEntity entity = new GenericEntity<User>(newUser){};
-        //String json = "{\"api-key\": \"" + newUser.getToken() + "\"}";
-        //return Response.ok(json, MediaType.APPLICATION_JSON).build();
         return Response.ok(entity).build();
     }
 

--- a/src/main/java/edu/harvard/lib/librarycloud/collections/CollectionsAPI.java
+++ b/src/main/java/edu/harvard/lib/librarycloud/collections/CollectionsAPI.java
@@ -323,7 +323,7 @@ public class CollectionsAPI {
         if (user == null) { //user not found.
             throw new LibraryCloudCollectionsException("Not Authorized", Status.UNAUTHORIZED);
         }
-        if (!user.getRole().equals("3")) { //user not admin status.
+        if (!user.getRole().equals("3")) { //user not admin status - TO DO: check on "admin" rather than 3, need method
             throw new LibraryCloudCollectionsException("Not Authorized", Status.UNAUTHORIZED);
         }
         try {

--- a/src/main/java/edu/harvard/lib/librarycloud/collections/dao/CollectionDAO.java
+++ b/src/main/java/edu/harvard/lib/librarycloud/collections/dao/CollectionDAO.java
@@ -143,6 +143,24 @@ public class CollectionDAO  {
         }
     }
 
+    /**
+     * Get User from Email
+     * @param  email Email of the user to look for
+     * @return                  User for that email.
+     */
+
+    private User getUserForEmail(String email) {
+        String query = "SELECT u FROM User u " +
+                "WHERE u.email = :email";
+        try {
+            User result = em.createQuery(query, User.class)
+                    .setParameter("email", email).setMaxResults(1)
+                    .getSingleResult();
+            return result;
+        } catch (NoResultException e) {
+            return null;
+        }
+    }
 
     /**
      * Retrieve items and associated collections based on list of IDs
@@ -254,12 +272,17 @@ public class CollectionDAO  {
     }
 
     @Transactional
-    public Integer createUser(User user) {
+    public User createUser(User user) {
+        if (getUserForEmail(user.getEmail()) != null) {
+            user = getUserForEmail(user.getEmail());
+        }
+        else {
         String key = UUID.randomUUID().toString();
         user.setToken(key);
+        }
         em.persist(user);
         em.flush();
-        return user.getId();
+        return user;
     }
 
     public User getUserById(int id) {

--- a/src/main/java/edu/harvard/lib/librarycloud/collections/dao/CollectionDAO.java
+++ b/src/main/java/edu/harvard/lib/librarycloud/collections/dao/CollectionDAO.java
@@ -277,12 +277,22 @@ public class CollectionDAO  {
             user = getUserForEmail(user.getEmail());
         }
         else {
-        String key = UUID.randomUUID().toString();
-        user.setToken(key);
+            String key = UUID.randomUUID().toString();
+            user.setToken(key);
+            UserType userType = getUserTypeForName(user.getUserTypeName());
+            user.setUserType(userType.getId());
         }
         em.persist(user);
         em.flush();
         return user;
+    }
+
+    public UserType getUserTypeForName(String name) {
+        String query = "select ut from UserType ut Where ut.name  = :name";
+        UserType userType = em.createQuery(query, UserType.class)
+                .setParameter("name", name)
+                .getSingleResult();
+        return userType;
     }
 
     public User getUserById(int id) {

--- a/src/main/java/edu/harvard/lib/librarycloud/collections/model/User.java
+++ b/src/main/java/edu/harvard/lib/librarycloud/collections/model/User.java
@@ -25,7 +25,13 @@ public class User implements Principal {
 
   private String role;
 
- // @ManyToOne(cascade = CascadeType.ALL)
+  //using this as a proxy for actual userType.name, when creating a new user
+  // could be replaced if we can get relationship for user-usertype tables working
+  // so that passing userType as name can auto set the usertype_id in user
+  @Transient
+  private String userTypeName;
+
+  // @ManyToOne(cascade = CascadeType.ALL)
   @Column(name="usertype_id")
   //private UserType userType;
   private int userType;
@@ -81,15 +87,11 @@ public class User implements Principal {
         this.userType = userType;
     }
 
-  /*public UserType getUserType() {
-    return userType;
-  }
+  @XmlElement(name="user-type")
+  public String getUserTypeName() { return userTypeName; }
 
-  public void setUserType(UserType userType) {
-    this.userType = userType;
-  }
+  public void setUserTypeName (String userTypeName) { this.userTypeName = userTypeName; }
 
-   */
   @XmlElement(name = "api-key")
   public String getToken() {return token;}
 

--- a/src/main/java/edu/harvard/lib/librarycloud/collections/model/User.java
+++ b/src/main/java/edu/harvard/lib/librarycloud/collections/model/User.java
@@ -87,7 +87,7 @@ public class User implements Principal {
         this.userType = userType;
     }
 
-  @XmlElement(name="user-type")
+  @XmlElement(name="usertype-name")
   public String getUserTypeName() { return userTypeName; }
 
   public void setUserTypeName (String userTypeName) { this.userTypeName = userTypeName; }

--- a/src/main/java/edu/harvard/lib/librarycloud/collections/model/UserType.java
+++ b/src/main/java/edu/harvard/lib/librarycloud/collections/model/UserType.java
@@ -8,6 +8,7 @@ import java.security.*;
 @Table(name = "user_type")
 
 public class UserType {
+
     @Id
     @GeneratedValue
     private int id;
@@ -32,4 +33,6 @@ public class UserType {
     public void setDescription(String description) {
         this.description = description;
     }
+
+    public int getId() { return id; }
 }


### PR DESCRIPTION
When creating a user, if the user already exists, just pass back the api key, rather than throwing a unique error (based on email)
Also, createUser now takes "user-type":"HDC" (for example), rather than "userType":2 (along with email)