### PR TITLE
Limit user collections and fix setspec issue

### DIFF
--- a/src/main/java/edu/harvard/lib/librarycloud/collections/CollectionsAPI.java
+++ b/src/main/java/edu/harvard/lib/librarycloud/collections/CollectionsAPI.java
@@ -389,6 +389,10 @@ public class CollectionsAPI {
             throw new LibraryCloudCollectionsException("You have already created the maximum amount of collections", Status.UNAUTHORIZED);
         }
 
+        if (collectionDao.doesUserAlreadyHaveSetWithTitle(user, collection)) {
+            throw new LibraryCloudCollectionsException("A collection with that name already exists", Status.UNAUTHORIZED);
+        }
+
         Integer id = collectionDao.createCollection(collection, user);
         UriBuilder uriBuilder = uriInfo.getAbsolutePathBuilder();
         URI uri = uriBuilder.path(id.toString()).build();

--- a/src/main/java/edu/harvard/lib/librarycloud/collections/CollectionsAPI.java
+++ b/src/main/java/edu/harvard/lib/librarycloud/collections/CollectionsAPI.java
@@ -385,9 +385,7 @@ public class CollectionsAPI {
             throw new LibraryCloudCollectionsException("Not Authorized", Status.UNAUTHORIZED);
         }
 
-        int userCollectionCount = collectionDao.getUserCollectionsForUser(user).size();
-        if (userCollectionCount >= 1000) {
-            // limit the amount of collections a user can create to the above
+        if (collectionDao.hasUserCreatedMaxAllowedSets(user)) {
             throw new LibraryCloudCollectionsException("You have already created the maximum amount of collections", Status.UNAUTHORIZED);
         }
 

--- a/src/main/java/edu/harvard/lib/librarycloud/collections/CollectionsAPI.java
+++ b/src/main/java/edu/harvard/lib/librarycloud/collections/CollectionsAPI.java
@@ -385,6 +385,12 @@ public class CollectionsAPI {
             throw new LibraryCloudCollectionsException("Not Authorized", Status.UNAUTHORIZED);
         }
 
+        int userCollectionCount = collectionDao.getUserCollectionsForUser(user).size();
+        if (userCollectionCount >= 1000) {
+            // limit the amount of collections a user can create to the above
+            throw new LibraryCloudCollectionsException("You have already created the maximum amount of collections", Status.UNAUTHORIZED);
+        }
+
         Integer id = collectionDao.createCollection(collection, user);
         UriBuilder uriBuilder = uriInfo.getAbsolutePathBuilder();
         URI uri = uriBuilder.path(id.toString()).build();

--- a/src/main/java/edu/harvard/lib/librarycloud/collections/dao/CollectionDAO.java
+++ b/src/main/java/edu/harvard/lib/librarycloud/collections/dao/CollectionDAO.java
@@ -607,7 +607,7 @@ public class CollectionDAO  {
         return result;
     }
 
-    private List<UserCollection> getUserCollectionsForUser(User u) {
+    public List<UserCollection> getUserCollectionsForUser(User u) {
         String query = "select uc from UserCollection uc WHERE uc.user.id = :userId";
         List<UserCollection> result = em.createQuery(query, UserCollection.class)
             .setParameter("userId", u.getId())

--- a/src/main/java/edu/harvard/lib/librarycloud/collections/dao/CollectionDAO.java
+++ b/src/main/java/edu/harvard/lib/librarycloud/collections/dao/CollectionDAO.java
@@ -366,7 +366,8 @@ public class CollectionDAO  {
     public Integer createCollection(Collection c, User u) {
         //first save the collection to generate an Id
         if (u.getUserType() == 2) {
-            String hdcSetSpec = "hdc_" + c.getSetName().toLowerCase().replace(" ", "").replace(":","") + "_" + u.getId();
+            String setName = c.getSetName();
+            String hdcSetSpec = "hdc_" + setName.toLowerCase().replace(" ", "").replace(":","") + "_" + setName.length() + "_" + u.getId();
             c.setSetSpec(hdcSetSpec);
         }
         em.persist(c);
@@ -668,4 +669,21 @@ public class CollectionDAO  {
         return false;
     }
 
+    public boolean doesUserAlreadyHaveSetWithTitle(User user, Collection collection) {
+        String query = "SELECT c FROM Collection c WHERE c.setName = :title";
+        List<Collection> foundCollections = em.createQuery(query, Collection.class)
+            .setParameter("title", collection.getSetName())
+            .getResultList();
+
+        for (Collection c : foundCollections) {
+            List<UserCollection> ucs = getUserCollections(c);
+            for (UserCollection uc : ucs) {
+                if (uc.getUser().getId() == user.getId()) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
 }

--- a/src/main/java/edu/harvard/lib/librarycloud/collections/dao/CollectionDAO.java
+++ b/src/main/java/edu/harvard/lib/librarycloud/collections/dao/CollectionDAO.java
@@ -659,6 +659,13 @@ public class CollectionDAO  {
         return coll;
     }
 
-
+    public boolean hasUserCreatedMaxAllowedSets(User user) {
+        int userCollectionCount = getUserCollectionsForUser(user).size();
+        if (userCollectionCount >= 1000) {
+            // limit the amount of collections a user can create to the above value
+            return true;
+        }
+        return false;
+    }
 
 }


### PR DESCRIPTION
This addition disallows the user from creating over 1000 sets (number is currently a placeholder and can be changed).

It also fixes a couple little uses with setSpec and titling. Now, a user is alerted if they try to enter a duplicate title before breaking the setSpec. Titles are treated case insensitively, so "Collection 1" and "collection 1" will count as a duplicate, but spaces ARE counted, so "Collection1" and "Collection 1" are both allowed. This check is only within the constraints of a particular user, so if one user has a "Collection 1" another user can also create "Collection 1".