### PR TITLE
Moved max collections per user to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ The LibraryCloud Collections API provides access to metadata about groups of ite
     cp src/main/resources/librarycloud.collections.env.properties.example src/main/resources/librarycloud.collections.env.properties
 
 Upate  ```librarycloud.collections.env``` with the AWS keys and SQS environment name to use. (The SQS environment sets the prefix that's added to all LibraryCloud queues)
+```max_collections_per_user``` defines the maximum amount of collections that a user is allowed to create, and should be set to an integer of your choice.
 
 ### Database setup and migrations
 Database connection settings can be configured in the following places:

--- a/src/main/java/edu/harvard/lib/librarycloud/collections/Config.java
+++ b/src/main/java/edu/harvard/lib/librarycloud/collections/Config.java
@@ -69,6 +69,7 @@ public class Config {
     public String SQS_ENVIRONMENT;
     public Boolean REQUEST_LOGGING;
     public String HDC_KEY;
+    public int maxCollectionsPerUser;
 
     private static Config conf;
     public static String propFile = "librarycloud.collections.env.properties";
@@ -177,6 +178,7 @@ public class Config {
         SQS_ENVIRONMENT = props.getProperty("librarycloud.sqs.environment");
         REQUEST_LOGGING = "true".equals(props.getProperty("librarycloud.request_logging"));
         HDC_KEY = props.getProperty("hdc_key");
+        maxCollectionsPerUser = Integer.parseInt(props.getProperty("max_collections_per_user"));
     }
 
     public static synchronized Config getInstance() {

--- a/src/main/java/edu/harvard/lib/librarycloud/collections/dao/CollectionDAO.java
+++ b/src/main/java/edu/harvard/lib/librarycloud/collections/dao/CollectionDAO.java
@@ -661,8 +661,9 @@ public class CollectionDAO  {
     }
 
     public boolean hasUserCreatedMaxAllowedSets(User user) {
+        Config config = Config.getInstance();
         int userCollectionCount = getUserCollectionsForUser(user).size();
-        if (userCollectionCount >= 1000) {
+        if (userCollectionCount >= config.maxCollectionsPerUser) {
             // limit the amount of collections a user can create to the above value
             return true;
         }

--- a/src/main/resources/librarycloud.collections.env.properties.example
+++ b/src/main/resources/librarycloud.collections.env.properties.example
@@ -12,3 +12,4 @@ tomcat.password=PASSWORD
 librarycloud.sqs.environment=ENV
 aws.access.key=KEY
 aws.secret.key=KEY
+max_collections_per_user=1000

--- a/src/test/resources/librarycloud.collections.test.env.properties.example
+++ b/src/test/resources/librarycloud.collections.test.env.properties.example
@@ -2,3 +2,4 @@ base_test_url=http://localhost:8080/collections/
 db_url=jdbc:mysql://127.0.0.1:3306/librarycloud_collections_test
 db_user=librarycloud
 db_password=harvard
+max_collections_per_user=1000


### PR DESCRIPTION
To address @michael-lts 's comment on my previous PR, I've moved the max collections per user into config. Readme and both properties example files have been updated to reflect.