### PR TITLE
collectionSize works when getting an HDC users collection. Excluded f…

### DIFF
--- a/src/main/java/edu/harvard/lib/librarycloud/collections/CollectionsAPI.java
+++ b/src/main/java/edu/harvard/lib/librarycloud/collections/CollectionsAPI.java
@@ -122,8 +122,14 @@ public class CollectionsAPI {
 
         User user = (User)securityContext.getUserPrincipal();
 
-        Collection c = collectionDao.getCollection(id);
-
+        Collection c;
+        // TODO: REFACTOR SO AS NOT TO USE THE ID OF THE USER TYPE (2 = "HDC" IN THIS CASE) AND USE THE NAME INSTEAD "HDC"
+        if (user.getUserType() == 2) {
+            c = collectionDao.getCollection(id, true);
+        } else {
+            c = collectionDao.getCollection(id);
+        }
+        
         if (c == null) {
             throw new NotFoundException();
         }

--- a/src/main/java/edu/harvard/lib/librarycloud/collections/dao/CollectionDAO.java
+++ b/src/main/java/edu/harvard/lib/librarycloud/collections/dao/CollectionDAO.java
@@ -262,14 +262,23 @@ public class CollectionDAO  {
      * @param  id Internal ID of the collection
      * @return    Populated Collection, or null if not found
      */
-    public Collection getCollection(Integer id) {
+    public Collection getCollection(Integer id, boolean includeItemCount) {
         Collection result;
         try {
             result = em.find(Collection.class, id);
+            if (includeItemCount) {
+                int amountOfItems = getItems(result).size();
+                result.setCollectionSize(amountOfItems);
+            }
         } catch (NoResultException e) {
             return null;
         }
         return result;
+    }
+
+    public Collection getCollection(Integer id) {
+        // default is to not include item count
+        return getCollection(id, false);
     }
 
     @Transactional

--- a/src/main/java/edu/harvard/lib/librarycloud/collections/model/Collection.java
+++ b/src/main/java/edu/harvard/lib/librarycloud/collections/model/Collection.java
@@ -161,14 +161,14 @@ public class Collection  {
     }
 
     @Transient
-    private int collectionSize;
+    private Integer collectionSize;
 
     @XmlElement(name="collectionSize")
-    public int getCollectionSize() {
+    public Integer getCollectionSize() {
       return collectionSize;
     }
 
-    public void setCollectionSize(int newCollectionSize) {
+    public void setCollectionSize(Integer newCollectionSize) {
       this.collectionSize = newCollectionSize;
     }
 


### PR DESCRIPTION
…rom response in cases where its not needed

Collection size is now calculated and included in the response if getting a collection for an HDC user. It still functions when getting all of a user's collections.  
Collection size no longer is included in the response set to zero with other calls to the API.
The getCollection method has been modified to only attach an itemCount if its specifically asked for through a parameter.