### PR TITLE
reworked max collections per user test, removed createUserV1, and mov…

### DIFF
--- a/src/main/java/edu/harvard/lib/librarycloud/collections/CollectionsAPI.java
+++ b/src/main/java/edu/harvard/lib/librarycloud/collections/CollectionsAPI.java
@@ -330,21 +330,6 @@ public class CollectionsAPI {
     /**
      * Create a user
      */
-    @POST @Path("collections/users_v1")
-    @Consumes({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
-    public Response createUserV1(User user) {
-/*
-        User user = (User)securityContext.getUserPrincipal();
-
-        if (user == null) { //user not found.
-            return Response.status(Status.UNAUTHORIZED).build();
-        }
-*/
-        Integer id = collectionDao.createUserV1(user);
-        UriBuilder uriBuilder = uriInfo.getAbsolutePathBuilder();
-        URI uri = uriBuilder.path(id.toString()).build();
-        return Response.created(uri).build();
-    }
 
     @DELETE @Path("collections/users/")
     public Response deleteUser() {

--- a/src/main/java/edu/harvard/lib/librarycloud/collections/dao/CollectionDAO.java
+++ b/src/main/java/edu/harvard/lib/librarycloud/collections/dao/CollectionDAO.java
@@ -282,15 +282,6 @@ public class CollectionDAO  {
     }
 
     @Transactional
-    public Integer createUserV1(User user) {
-        Config config = Config.getInstance();
-        user.setToken(config.HDC_KEY);
-        em.persist(user);
-        em.flush();
-        return user.getId();
-    }
-
-    @Transactional
     public User createUser(User user) {
         if (getUserForEmail(user.getEmail()) != null) {
             user = getUserForEmail(user.getEmail());
@@ -669,14 +660,20 @@ public class CollectionDAO  {
         return coll;
     }
 
-    public boolean hasUserCreatedMaxAllowedSets(User user) {
-        Config config = Config.getInstance();
+    public boolean hasUserCreatedMaxAllowedSets(User user, int maxAllowedSets) {
+        // We're using this pattern so the method is testable without using the default config
+        // So far during normal use cases, only the user is used with this method
         int userCollectionCount = getUserCollectionsForUser(user).size();
-        if (userCollectionCount >= config.maxCollectionsPerUser) {
+        if (userCollectionCount >= maxAllowedSets) {
             // limit the amount of collections a user can create to the above value
             return true;
         }
         return false;
+    }
+
+    public boolean hasUserCreatedMaxAllowedSets(User user) {
+        Config config = Config.getInstance();
+        return hasUserCreatedMaxAllowedSets(user, config.maxCollectionsPerUser);
     }
 
     public boolean doesUserAlreadyHaveSetWithTitle(User user, Collection collection) {


### PR DESCRIPTION
Reworked max collections per user test to use test properties file instead of the main one, removed createUserV1 and associated API call, and moved testing of getUserById to createUser test (instead of createUserV1)