### PR TITLE
Resolving Get Collections for Item Bug

### DIFF
--- a/src/main/java/edu/harvard/lib/librarycloud/collections/CollectionsAPI.java
+++ b/src/main/java/edu/harvard/lib/librarycloud/collections/CollectionsAPI.java
@@ -177,7 +177,7 @@ public class CollectionsAPI {
     @JSONP(queryParam = "callback")
     @Produces({"application/javascript", MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML + ";qs=0.9"})
     public List<Collection> getCollectionsForItem(
-                                          @PathParam("id") Integer id
+                                          @PathParam("id") String id
                                           ) {
         User user = (User)securityContext.getUserPrincipal();
         
@@ -193,7 +193,17 @@ public class CollectionsAPI {
         if (collections == null) {
             throw new NotFoundException();
         }
-        return collections;
+
+        List<Collection> collectionsThatBelongToUser = new ArrayList<Collection>();
+        for (Collection c : collections) {
+            if (collectionDao.isUserOwner(c, user)) {
+                collectionsThatBelongToUser.add(c);
+            }
+        }
+        if (collectionsThatBelongToUser.size() == 0) {
+            throw new LibraryCloudCollectionsException("Not Authorized", Status.UNAUTHORIZED);
+        }
+        return collectionsThatBelongToUser;
     }
 
     /**


### PR DESCRIPTION
If logged in as a user, you could previously use the Get Collection For Item endpoint with an item ID to get all collections associated with that item. However, it would not screen these collections by owner, resulting in the unlikely situation that someone sends an item id to get another user's collections.
This PR fixes that bug, and now the endpoint only returns collections owned by the current user.